### PR TITLE
Fix install paths for ign -> gz changes

### DIFF
--- a/ubuntu/debian/libignition-sensors-air-pressure-dev.install
+++ b/ubuntu/debian/libignition-sensors-air-pressure-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/air_pressure/*
-usr/include/ignition/sensors*/ignition/sensors/AirPressure*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-air_pressure/*
-usr/lib/*/libignition-sensors[0-99]-air_pressure.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-air_pressure.pc
+usr/include/*/sensors*/*/sensors/air_pressure/*
+usr/include/*/sensors*/*/sensors/AirPressure*.hh
+usr/lib/*/cmake/*-sensors[0-99]-air_pressure/*
+usr/lib/*/lib*-sensors[0-99]-air_pressure.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-air_pressure.pc

--- a/ubuntu/debian/libignition-sensors-air-pressure.install
+++ b/ubuntu/debian/libignition-sensors-air-pressure.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-air_pressure.so.*
+usr/lib/*/lib*-sensors[0-99]-air_pressure.so.*

--- a/ubuntu/debian/libignition-sensors-altimeter-dev.install
+++ b/ubuntu/debian/libignition-sensors-altimeter-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/altimeter/*
-usr/include/ignition/sensors*/ignition/sensors/Altimeter*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-altimeter/*
-usr/lib/*/libignition-sensors[0-99]-altimeter.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-altimeter.pc
+usr/include/*/sensors*/*/sensors/altimeter/*
+usr/include/*/sensors*/*/sensors/Altimeter*.hh
+usr/lib/*/cmake/*-sensors[0-99]-altimeter/*
+usr/lib/*/lib*-sensors[0-99]-altimeter.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-altimeter.pc

--- a/ubuntu/debian/libignition-sensors-altimeter.install
+++ b/ubuntu/debian/libignition-sensors-altimeter.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-altimeter.so.*
+usr/lib/*/lib*-sensors[0-99]-altimeter.so.*

--- a/ubuntu/debian/libignition-sensors-boundingbox-camera-dev.install
+++ b/ubuntu/debian/libignition-sensors-boundingbox-camera-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/boundingbox_camera/*
-usr/include/ignition/sensors*/ignition/sensors/BoundingBoxCamera*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-boundingbox_camera/*
-usr/lib/*/libignition-sensors[0-99]-boundingbox_camera.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-boundingbox_camera.pc
+usr/include/*/sensors*/*/sensors/boundingbox_camera/*
+usr/include/*/sensors*/*/sensors/BoundingBoxCamera*.hh
+usr/lib/*/cmake/*-sensors[0-99]-boundingbox_camera/*
+usr/lib/*/lib*-sensors[0-99]-boundingbox_camera.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-boundingbox_camera.pc

--- a/ubuntu/debian/libignition-sensors-boundingbox-camera.install
+++ b/ubuntu/debian/libignition-sensors-boundingbox-camera.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-boundingbox_camera.so.*
+usr/lib/*/lib*-sensors[0-99]-boundingbox_camera.so.*

--- a/ubuntu/debian/libignition-sensors-camera-dev.install
+++ b/ubuntu/debian/libignition-sensors-camera-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/camera/*
-usr/include/ignition/sensors*/ignition/sensors/Camera*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-camera/*
-usr/lib/*/libignition-sensors[0-99]-camera.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-camera.pc
+usr/include/*/sensors*/*/sensors/camera/*
+usr/include/*/sensors*/*/sensors/Camera*.hh
+usr/lib/*/cmake/*-sensors[0-99]-camera/*
+usr/lib/*/lib*-sensors[0-99]-camera.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-camera.pc

--- a/ubuntu/debian/libignition-sensors-camera.install
+++ b/ubuntu/debian/libignition-sensors-camera.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-camera.so.*
+usr/lib/*/lib*-sensors[0-99]-camera.so.*

--- a/ubuntu/debian/libignition-sensors-core-dev.install
+++ b/ubuntu/debian/libignition-sensors-core-dev.install
@@ -1,6 +1,6 @@
-usr/include/ignition/sensors[0-99]/ignition/sensors.hh
-usr/include/ignition/sensors[0-99]/ignition/sensors/*.hh
-usr/include/ignition/sensors[0-99]/ignition/sensors/detail/*.hh
-usr/lib/*/libignition-sensors[0-99].so
-usr/lib/*/pkgconfig/ignition-sensors[0-99].pc
-usr/lib/*/cmake/ignition-sensors[0-99]/ignition-sensors*
+usr/include/*/sensors[0-99]/*/sensors.hh
+usr/include/*/sensors[0-99]/*/sensors/*.hh
+usr/include/*/sensors[0-99]/*/sensors/detail/*.hh
+usr/lib/*/lib*-sensors[0-99].so
+usr/lib/*/pkgconfig/*-sensors[0-99].pc
+usr/lib/*/cmake/*-sensors[0-99]/*-sensors*

--- a/ubuntu/debian/libignition-sensors-depth-camera-dev.install
+++ b/ubuntu/debian/libignition-sensors-depth-camera-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/depth_camera/*
-usr/include/ignition/sensors*/ignition/sensors/DepthCamera*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-depth_camera/*
-usr/lib/*/libignition-sensors[0-99]-depth_camera.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-depth_camera.pc
+usr/include/*/sensors*/*/sensors/depth_camera/*
+usr/include/*/sensors*/*/sensors/DepthCamera*.hh
+usr/lib/*/cmake/*-sensors[0-99]-depth_camera/*
+usr/lib/*/lib*-sensors[0-99]-depth_camera.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-depth_camera.pc

--- a/ubuntu/debian/libignition-sensors-depth-camera.install
+++ b/ubuntu/debian/libignition-sensors-depth-camera.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-depth_camera.so.*
+usr/lib/*/lib*-sensors[0-99]-depth_camera.so.*

--- a/ubuntu/debian/libignition-sensors-dev.install
+++ b/ubuntu/debian/libignition-sensors-dev.install
@@ -1,1 +1,1 @@
-usr/lib/*/cmake/ignition-sensors[0-99]-all/ignition-sensors[0-99]-all*
+usr/lib/*/cmake/*-sensors[0-99]-all/*-sensors[0-99]-all*

--- a/ubuntu/debian/libignition-sensors-force-torque-dev.install
+++ b/ubuntu/debian/libignition-sensors-force-torque-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/force_torque/*
-usr/include/ignition/sensors*/ignition/sensors/ForceTorque*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-force_torque/*
-usr/lib/*/libignition-sensors[0-99]-force_torque.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-force_torque.pc
+usr/include/*/sensors*/*/sensors/force_torque/*
+usr/include/*/sensors*/*/sensors/ForceTorque*.hh
+usr/lib/*/cmake/*-sensors[0-99]-force_torque/*
+usr/lib/*/lib*-sensors[0-99]-force_torque.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-force_torque.pc

--- a/ubuntu/debian/libignition-sensors-force-torque.install
+++ b/ubuntu/debian/libignition-sensors-force-torque.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-force_torque.so.*
+usr/lib/*/lib*-sensors[0-99]-force_torque.so.*

--- a/ubuntu/debian/libignition-sensors-gpu-lidar-dev.install
+++ b/ubuntu/debian/libignition-sensors-gpu-lidar-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/gpu_lidar/*
-usr/include/ignition/sensors*/ignition/sensors/GpuLidar*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-gpu_lidar/*
-usr/lib/*/libignition-sensors[0-99]-gpu_lidar.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-gpu_lidar.pc
+usr/include/*/sensors*/*/sensors/gpu_lidar/*
+usr/include/*/sensors*/*/sensors/GpuLidar*.hh
+usr/lib/*/cmake/*-sensors[0-99]-gpu_lidar/*
+usr/lib/*/lib*-sensors[0-99]-gpu_lidar.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-gpu_lidar.pc

--- a/ubuntu/debian/libignition-sensors-gpu-lidar.install
+++ b/ubuntu/debian/libignition-sensors-gpu-lidar.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-gpu_lidar.so.*
+usr/lib/*/lib*-sensors[0-99]-gpu_lidar.so.*

--- a/ubuntu/debian/libignition-sensors-imu-dev.install
+++ b/ubuntu/debian/libignition-sensors-imu-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/imu/*
-usr/include/ignition/sensors*/ignition/sensors/Imu*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-imu/*
-usr/lib/*/libignition-sensors[0-99]-imu.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-imu.pc
+usr/include/*/sensors*/*/sensors/imu/*
+usr/include/*/sensors*/*/sensors/Imu*.hh
+usr/lib/*/cmake/*-sensors[0-99]-imu/*
+usr/lib/*/lib*-sensors[0-99]-imu.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-imu.pc

--- a/ubuntu/debian/libignition-sensors-imu.install
+++ b/ubuntu/debian/libignition-sensors-imu.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-imu.so.*
+usr/lib/*/lib*-sensors[0-99]-imu.so.*

--- a/ubuntu/debian/libignition-sensors-lidar-dev.install
+++ b/ubuntu/debian/libignition-sensors-lidar-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/lidar/*
-usr/include/ignition/sensors*/ignition/sensors/Lidar*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-lidar/*
-usr/lib/*/libignition-sensors[0-99]-lidar.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-lidar.pc
+usr/include/*/sensors*/*/sensors/lidar/*
+usr/include/*/sensors*/*/sensors/Lidar*.hh
+usr/lib/*/cmake/*-sensors[0-99]-lidar/*
+usr/lib/*/lib*-sensors[0-99]-lidar.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-lidar.pc

--- a/ubuntu/debian/libignition-sensors-lidar.install
+++ b/ubuntu/debian/libignition-sensors-lidar.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-lidar.so.*
+usr/lib/*/lib*-sensors[0-99]-lidar.so.*

--- a/ubuntu/debian/libignition-sensors-logical-camera-dev.install
+++ b/ubuntu/debian/libignition-sensors-logical-camera-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/logical_camera/*
-usr/include/ignition/sensors*/ignition/sensors/LogicalCamera*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-logical_camera/*
-usr/lib/*/libignition-sensors[0-99]-logical_camera.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-logical_camera.pc
+usr/include/*/sensors*/*/sensors/logical_camera/*
+usr/include/*/sensors*/*/sensors/LogicalCamera*.hh
+usr/lib/*/cmake/*-sensors[0-99]-logical_camera/*
+usr/lib/*/lib*-sensors[0-99]-logical_camera.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-logical_camera.pc

--- a/ubuntu/debian/libignition-sensors-logical-camera.install
+++ b/ubuntu/debian/libignition-sensors-logical-camera.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-logical_camera.so.*
+usr/lib/*/lib*-sensors[0-99]-logical_camera.so.*

--- a/ubuntu/debian/libignition-sensors-magnetometer-dev.install
+++ b/ubuntu/debian/libignition-sensors-magnetometer-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/magnetometer/*
-usr/include/ignition/sensors*/ignition/sensors/Magnetometer*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-magnetometer/*
-usr/lib/*/libignition-sensors[0-99]-magnetometer.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-magnetometer.pc
+usr/include/*/sensors*/*/sensors/magnetometer/*
+usr/include/*/sensors*/*/sensors/Magnetometer*.hh
+usr/lib/*/cmake/*-sensors[0-99]-magnetometer/*
+usr/lib/*/lib*-sensors[0-99]-magnetometer.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-magnetometer.pc

--- a/ubuntu/debian/libignition-sensors-magnetometer.install
+++ b/ubuntu/debian/libignition-sensors-magnetometer.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-magnetometer.so.*
+usr/lib/*/lib*-sensors[0-99]-magnetometer.so.*

--- a/ubuntu/debian/libignition-sensors-navsat-dev.install
+++ b/ubuntu/debian/libignition-sensors-navsat-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/navsat/*
-usr/include/ignition/sensors*/ignition/sensors/NavSat*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-navsat/*
-usr/lib/*/libignition-sensors[0-99]-navsat.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-navsat.pc
+usr/include/*/sensors*/*/sensors/navsat/*
+usr/include/*/sensors*/*/sensors/NavSat*.hh
+usr/lib/*/cmake/*-sensors[0-99]-navsat/*
+usr/lib/*/lib*-sensors[0-99]-navsat.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-navsat.pc

--- a/ubuntu/debian/libignition-sensors-navsat.install
+++ b/ubuntu/debian/libignition-sensors-navsat.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-navsat.so.*
+usr/lib/*/lib*-sensors[0-99]-navsat.so.*

--- a/ubuntu/debian/libignition-sensors-rendering-dev.install
+++ b/ubuntu/debian/libignition-sensors-rendering-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/rendering/*
-usr/include/ignition/sensors*/ignition/sensors/Rendering*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-rendering/*
-usr/lib/*/libignition-sensors[0-99]-rendering.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-rendering.pc
+usr/include/*/sensors*/*/sensors/rendering/*
+usr/include/*/sensors*/*/sensors/Rendering*.hh
+usr/lib/*/cmake/*-sensors[0-99]-rendering/*
+usr/lib/*/lib*-sensors[0-99]-rendering.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-rendering.pc

--- a/ubuntu/debian/libignition-sensors-rendering.install
+++ b/ubuntu/debian/libignition-sensors-rendering.install
@@ -1,0 +1,1 @@
+usr/lib/*/lib*-sensors[0-99]-rendering.so.*

--- a/ubuntu/debian/libignition-sensors-rendering.isntall
+++ b/ubuntu/debian/libignition-sensors-rendering.isntall
@@ -1,1 +1,0 @@
-usr/lib/*/libignition-sensors[0-99]-rendering.so.*

--- a/ubuntu/debian/libignition-sensors-rgbd-camera-dev.install
+++ b/ubuntu/debian/libignition-sensors-rgbd-camera-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/rgbd_camera/*
-usr/include/ignition/sensors*/ignition/sensors/RgbdCamera*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-rgbd_camera/*
-usr/lib/*/libignition-sensors[0-99]-rgbd_camera.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-rgbd_camera.pc
+usr/include/*/sensors*/*/sensors/rgbd_camera/*
+usr/include/*/sensors*/*/sensors/RgbdCamera*.hh
+usr/lib/*/cmake/*-sensors[0-99]-rgbd_camera/*
+usr/lib/*/lib*-sensors[0-99]-rgbd_camera.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-rgbd_camera.pc

--- a/ubuntu/debian/libignition-sensors-rgbd-camera.install
+++ b/ubuntu/debian/libignition-sensors-rgbd-camera.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-rgbd_camera.so.*
+usr/lib/*/lib*-sensors[0-99]-rgbd_camera.so.*

--- a/ubuntu/debian/libignition-sensors-segmentation-camera-dev.install
+++ b/ubuntu/debian/libignition-sensors-segmentation-camera-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/segmentation_camera/*
-usr/include/ignition/sensors*/ignition/sensors/SegmentationCamera*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-segmentation_camera/*
-usr/lib/*/libignition-sensors[0-99]-segmentation_camera.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-segmentation_camera.pc
+usr/include/*/sensors*/*/sensors/segmentation_camera/*
+usr/include/*/sensors*/*/sensors/SegmentationCamera*.hh
+usr/lib/*/cmake/*-sensors[0-99]-segmentation_camera/*
+usr/lib/*/lib*-sensors[0-99]-segmentation_camera.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-segmentation_camera.pc

--- a/ubuntu/debian/libignition-sensors-segmentation-camera.install
+++ b/ubuntu/debian/libignition-sensors-segmentation-camera.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-segmentation_camera.so.*
+usr/lib/*/lib*-sensors[0-99]-segmentation_camera.so.*

--- a/ubuntu/debian/libignition-sensors-thermal-camera-dev.install
+++ b/ubuntu/debian/libignition-sensors-thermal-camera-dev.install
@@ -1,5 +1,5 @@
-usr/include/ignition/sensors*/ignition/sensors/thermal_camera/*
-usr/include/ignition/sensors*/ignition/sensors/ThermalCamera*.hh
-usr/lib/*/cmake/ignition-sensors[0-99]-thermal_camera/*
-usr/lib/*/libignition-sensors[0-99]-thermal_camera.so
-usr/lib/*/pkgconfig/ignition-sensors[0-99]-thermal_camera.pc
+usr/include/*/sensors*/*/sensors/thermal_camera/*
+usr/include/*/sensors*/*/sensors/ThermalCamera*.hh
+usr/lib/*/cmake/*-sensors[0-99]-thermal_camera/*
+usr/lib/*/lib*-sensors[0-99]-thermal_camera.so
+usr/lib/*/pkgconfig/*-sensors[0-99]-thermal_camera.pc

--- a/ubuntu/debian/libignition-sensors-thermal-camera.install
+++ b/ubuntu/debian/libignition-sensors-thermal-camera.install
@@ -1,1 +1,1 @@
-usr/lib/*/libignition-sensors[0-99]-thermal_camera.so.*
+usr/lib/*/lib*-sensors[0-99]-thermal_camera.so.*

--- a/ubuntu/debian/libignition-sensors.install
+++ b/ubuntu/debian/libignition-sensors.install
@@ -1,2 +1,2 @@
-usr/lib/*/libignition-sensors[0-99].so.*
-usr/share/ignition/ignition-sensors*/*
+usr/lib/*/lib*-sensors[0-99].so.*
+usr/share/*/*-sensors*/*


### PR DESCRIPTION
debbuilds are failing because of recent ign->gz changes from the forward port PR https://github.com/gazebosim/gz-sensors/pull/313, e.g.  https://build.osrfoundation.org/job/ign-sensors6-debbuilder/617

I replaced all occurrences of `ignition` with `*` in the install files so we install both gz and ignition files.

I also renamed `libignition-sensors-rendering.isntall` to `libignition-sensors-rendering.install` (fix `isntall` typo)